### PR TITLE
feat: Update test-failed functions

### DIFF
--- a/libft/Makefile
+++ b/libft/Makefile
@@ -6,11 +6,11 @@
 #    By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/12/02 22:48:59 by sanghupa          #+#    #+#              #
-#    Updated: 2022/12/13 19:56:27 by sanghupa         ###   ########.fr        #
+#    Updated: 2022/12/19 14:03:12 by sanghupa         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
-CC			= gcc
+CC			= cc
 
 CFLAGS		= -Wall -Werror -Wextra
 

--- a/libft/ft_putnbr_fd.c
+++ b/libft/ft_putnbr_fd.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/06 23:07:33 by sanghupa          #+#    #+#             */
-/*   Updated: 2022/12/06 23:29:00 by sanghupa         ###   ########.fr       */
+/*   Updated: 2022/12/19 14:04:45 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,10 @@
 void	ft_putnbr_fd(int n, int fd)
 {
 	if (n == INT_MIN)
+	{
 		write(fd, INT_MIN_STR, 11);
+		return ;
+	}
 	if (n < 0)
 	{
 		write(fd, "-", 1);

--- a/libft/ft_strchr.c
+++ b/libft/ft_strchr.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/05 12:21:01 by sanghupa          #+#    #+#             */
-/*   Updated: 2022/12/05 23:07:45 by sanghupa         ###   ########.fr       */
+/*   Updated: 2022/12/19 14:05:39 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,11 +25,11 @@ char	*ft_strchr(const char *s, int c)
 	i = 0;
 	while (s[i] != '\0')
 	{
-		if (s[i] == c)
+		if (s[i] == (char)c)
 			return ((char *)s + i);
 		i++;
 	}
-	if (s[i] == c)
+	if (s[i] == (char)c)
 		return ((char *)s + i);
 	return (0);
 }


### PR DESCRIPTION
- Update `Makefile` to compile with `cc`, not `gcc`.
- Update `ft_putnbr_fd.c` to return and not proceed after first if statement.
- Update `ft_strchr.c` to check input `c` more correctly in terms of for comparison of character.